### PR TITLE
Made dry grass trade available for the experimental trade set

### DIFF
--- a/fabric/src/main/java/de/larsensmods/stl_backport/fabric/SpringToLifeModFabric.java
+++ b/fabric/src/main/java/de/larsensmods/stl_backport/fabric/SpringToLifeModFabric.java
@@ -25,9 +25,9 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BiomeTags;
 import net.minecraft.tags.TagKey;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.animal.Animal;
+import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.trading.ItemCost;
@@ -72,7 +72,10 @@ public final class SpringToLifeModFabric implements ModInitializer {
         FuelRegistry.INSTANCE.add(STLItems.SHORT_DRY_GRASS.get(), 5 * 20);
         FuelRegistry.INSTANCE.add(STLItems.TALL_DRY_GRASS.get(), 5 * 20);
 
-        TradeOfferHelper.registerWanderingTraderOffers(1, factories -> factories.add((trader, random) -> new MerchantOffer(new ItemCost(Items.EMERALD, 1), new ItemStack(STLBlocks.TALL_DRY_GRASS.get()), 12, 0, 0)));
+        VillagerTrades.ItemListing dryGrassTrade = (trader, random) -> new MerchantOffer(new ItemCost(Items.EMERALD, 1), new ItemStack(STLBlocks.TALL_DRY_GRASS.get()), 12, 0, 0);
+        TradeOfferHelper.registerWanderingTraderOffers(1, factories -> factories.add(dryGrassTrade));
+        //noinspection UnstableApiUsage
+        TradeOfferHelper.registerRebalancedWanderingTraderOffers(wanderingTraderOffersBuilder -> wanderingTraderOffersBuilder.addOffersToPool(TradeOfferHelper.WanderingTraderOffersBuilder.SELL_COMMON_ITEMS_POOL, dryGrassTrade));
 
         this.applyBiomeModifications();
     }

--- a/neoforge/src/main/java/de/larsensmods/stl_backport/neoforge/event/GameEvents.java
+++ b/neoforge/src/main/java/de/larsensmods/stl_backport/neoforge/event/GameEvents.java
@@ -2,6 +2,7 @@ package de.larsensmods.stl_backport.neoforge.event;
 
 import de.larsensmods.stl_backport.SpringToLifeMod;
 import de.larsensmods.stl_backport.block.STLBlocks;
+import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.trading.ItemCost;
@@ -13,9 +14,11 @@ import net.neoforged.neoforge.event.village.WandererTradesEvent;
 @EventBusSubscriber(modid = SpringToLifeMod.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
 public class GameEvents {
 
+    public static final VillagerTrades.ItemListing DRY_GRASS_TRADE = (trader, random) -> new MerchantOffer(new ItemCost(Items.EMERALD, 1), new ItemStack(STLBlocks.TALL_DRY_GRASS.get()), 12, 0, 0);
+
     @SubscribeEvent
     public static void addWandererTrades(WandererTradesEvent event) {
-        event.getGenericTrades().add((trader, random) -> new MerchantOffer(new ItemCost(Items.EMERALD, 1), new ItemStack(STLBlocks.TALL_DRY_GRASS.get()), 12, 0, 0));
+        event.getGenericTrades().add(DRY_GRASS_TRADE);
     }
 
 }

--- a/neoforge/src/main/java/de/larsensmods/stl_backport/neoforge/mixin/VillagerTradesMixin.java
+++ b/neoforge/src/main/java/de/larsensmods/stl_backport/neoforge/mixin/VillagerTradesMixin.java
@@ -1,0 +1,25 @@
+package de.larsensmods.stl_backport.neoforge.mixin;
+
+import de.larsensmods.stl_backport.neoforge.event.GameEvents;
+import net.minecraft.world.entity.npc.VillagerTrades;
+import org.apache.commons.lang3.tuple.Pair;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(VillagerTrades.class)
+public class VillagerTradesMixin {
+
+    @Redirect(method = "<clinit>", at = @At(value = "INVOKE", target = "Lorg/apache/commons/lang3/tuple/Pair;of(Ljava/lang/Object;Ljava/lang/Object;)Lorg/apache/commons/lang3/tuple/Pair;", ordinal = 2))
+    private static Pair<VillagerTrades.ItemListing[], Integer> experimentalTradeAdders(Object left, Object right){
+        VillagerTrades.ItemListing[] castLeft = (VillagerTrades.ItemListing[]) left;
+        Integer castRight = (Integer) right;
+
+        VillagerTrades.ItemListing[] newLeft = new VillagerTrades.ItemListing[castLeft.length + 1];
+        System.arraycopy(castLeft, 0, newLeft, 0, castLeft.length);
+        newLeft[castLeft.length] = GameEvents.DRY_GRASS_TRADE;
+
+        return Pair.of(newLeft, castRight);
+    }
+
+}

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -29,3 +29,6 @@ side = "BOTH"
 
 [[mixins]]
 config = "spring_to_life.mixins.json"
+
+[[mixins]]
+config = "spring_to_life_neoforge.mixins.json"

--- a/neoforge/src/main/resources/spring_to_life_neoforge.mixins.json
+++ b/neoforge/src/main/resources/spring_to_life_neoforge.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "de.larsensmods.stl_backport.neoforge.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "minVersion": "0.8",
+  "client": [
+  ],
+  "mixins": [
+    "VillagerTradesMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Fixed the dry grass wandering trader trade not working with the experimental trade set enabled